### PR TITLE
Correct filename case [forge.exe => Forge.exe]

### DIFF
--- a/forge.rb
+++ b/forge.rb
@@ -11,7 +11,7 @@ class Forge < Formula
     libexec.install Dir["bin/*"]
     (bin/"forge").write <<-EOS.undent
       #!/bin/sh
-      mono #{libexec}/forge.exe "$@"
+      mono #{libexec}/Forge.exe "$@"
     EOS
   end
 end


### PR DESCRIPTION
I don't know if this is a problem on OS X, but using [Linuxbrew](http://linuxbrew.sh/) the `bin/forge` script fails to launch `mono forge.exe`.
Plus, it would make for greater consistency.
